### PR TITLE
feat: configure environment variables and secret mounts for frontend

### DIFF
--- a/charts/qcon-web/Chart.lock
+++ b/charts/qcon-web/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: apps-common
   repository: https://bcit-ltc.github.io/helm-charts
-  version: 0.3.0
-digest: sha256:91432b7e16f7c5ee4b479012dd11a954ec736bc6cf644dc4d394331d66c5a84b
-generated: "2025-10-17T22:42:42.691314-07:00"
+  version: 0.3.2
+digest: sha256:88d8606517b7113e17ddd311a8e2b8290c8d55496cb59e1ffe6bbb364387e34f
+generated: "2025-10-28T12:51:48.688596-07:00"

--- a/charts/qcon-web/values.yaml
+++ b/charts/qcon-web/values.yaml
@@ -84,8 +84,10 @@ frontend:
   port: 8080
   # -- List of extra environment variables that are set literally.
   # @default -- `[]`
-  extraEnvVars: []
-  # - API_URL: "https://app.example.com/api"
+  extraEnvVars:
+    - API_URL: "https://app.example.com/api"
+    - API_HOST: "qcon-api.ltc.bcit.ca"
+    - API_PORT: "8000"
   # -- configEnvs create ConfigMaps that are passed to containers using envFrom
   # @default -- `[]`
   configEnvs: []
@@ -119,7 +121,34 @@ frontend:
   #   storageClass: null
   # # -- Access Mode of the storage device being used for the PVC
   #   accessMode: ReadWriteOnce
-  secretMounts: []
+  secretMounts:
+    - name: app-internal-credentials
+      secretName: app-internal-credentials
+      mountPath: /etc/secrets
+      items:
+        - key: DJANGO_SECRET_KEY
+          path: app-internal-credentials/DJANGO_SECRET_KEY
+    - name: db-credentials
+      secretName: db-credentials
+      mountPath: /etc/secrets
+      readOnly: true
+      optional: false
+      items:
+        - key: POSTGRES_DB
+          path: db-credentials/POSTGRES_DB
+        - key: POSTGRES_USER
+          path: db-credentials/POSTGRES_USER
+        - key: POSTGRES_PASSWORD
+          path: db-credentials/POSTGRES_PASSWORD
+        - key: POSTGRES_HOST
+          path: db-credentials/POSTGRES_HOST
+    - name: api-key
+      secretName: api-key
+      mountPath: /etc/secrets
+      readOnly: true
+      items:
+        - key: API_KEY
+          path: api-key/API_KEY
   # # Credentials to access the app internal management portal (local account)
   # - name: app-internal-credentials # volume name (must be DNS-1123 compliant)
   #   secretName: app-internal-credentials # refers to existing Secret in the same namespace


### PR DESCRIPTION
- Added API environment variables including URL, host and port settings
- Configured secret mounts for database credentials, API key, and internal app credentials
- Set up volume mounts with specific paths for each secret category under /etc/secrets
- Added read-only and optional flags for sensitive credential mounts

Closes issue #12 
